### PR TITLE
fix: text color

### DIFF
--- a/src/app/[locale]/get-start/page.tsx
+++ b/src/app/[locale]/get-start/page.tsx
@@ -76,10 +76,10 @@ export default async function GetStart() {
             >
               {t("discussion")}
             </Link>
-            <a href="https://github.com/MirrorChyan/docs" target="_blank" className="text-sm/6 font-semibold">
+            <a href="https://github.com/MirrorChyan/docs" target="_blank" className="text-sm/6 font-semibold text-gray-900 dark:text-white">
               {t("apiDoc")}<span aria-hidden="true">&nbsp;→</span>
             </a>
-            <a href="https://github.com/MirrorChyan/user-frontend" target="_blank" className="text-sm/6 font-semibold">
+            <a href="https://github.com/MirrorChyan/user-frontend" target="_blank" className="text-sm/6 font-semibold text-gray-900 dark:text-white">
               {t("openSource")}<span aria-hidden="true">&nbsp;</span>
             </a>
           </div>


### PR DESCRIPTION
修复主页按键右侧链接文字显示
当系统主题色为白色时 文字不易见
![QQ_1742923973214](https://github.com/user-attachments/assets/772efedd-2c5c-4f0a-826b-34ad63e0dce0)
