### PR TITLE
fix: add ProjectLink component and integrate into show-key page

### DIFF
--- a/src/app/[locale]/show-key/page.tsx
+++ b/src/app/[locale]/show-key/page.tsx
@@ -6,6 +6,7 @@ import CopyButton from "@/components/CopyButton";
 import { Link } from "@/i18n/routing";
 import { SERVER_BACKEND } from "@/app/requests/misc";
 import QQGroupLink from "@/components/QQGroupLink";
+import ProjectLink from "@/components/ProjectLink";
 import { Suspense } from "react";
 import LoadingState from "@/components/LoadingState";
 
@@ -51,9 +52,12 @@ async function OrderContent({ order_id }: { order_id: string }) {
                 <span>{t("timeLeft", { relativeTime })}</span>
               </p>
             </div>
-            <p className="text-sm text-center mt-6">
+
+            <div className="text-sm text-center mt-6 flex justify-center gap-4">
               <QQGroupLink text={t("haveQuestion")} />
-            </p>
+              <ProjectLink text={t("viewProjects")} locale={locale} />
+            </div>
+
           </div>
         </div>
       </div>

--- a/src/components/ProjectLink.tsx
+++ b/src/components/ProjectLink.tsx
@@ -1,0 +1,21 @@
+import { Link } from "@/i18n/routing";
+import { useLocale } from "next-intl";
+
+export interface ProjectLinkProps {
+    text: string;
+    locale?: string;
+}
+
+export default function ProjectLink({ text, locale }: ProjectLinkProps) {
+    const currentLocale = locale || useLocale();
+
+    return (
+        <Link
+            href="/projects"
+            locale={currentLocale}
+            className="text-indigo-600 hover:text-indigo-500 dark:text-indigo-400 dark:hover:text-indigo-300 transition-colors"
+        >
+            {text}
+        </Link>
+    );
+}


### PR DESCRIPTION
Fix #124 

Introduces a new ProjectLink component for linking to the projects page with locale support. Updates the show-key page to display both QQGroupLink and ProjectLink for improved navigation.