### PR TITLE
Release 20250807 - 禁止同CDK转移

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -154,6 +154,7 @@
     "rewardUsedUp": "Redeem code has been used up",
     "rewardValidDays": "Can redeem for {valid_days} days",
     "fromNotFound": "Invalid key, Please check!",
+    "sameCdk": "Target CDKey cannot be the same as source CDKey",
     "transferTip": "After transfer, the original CDK will expire. Please confirm."
   },
   "Component": {

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -149,6 +149,7 @@
     "rewardUsedUp": "兑换码已发放完",
     "rewardValidDays": "可兑换 {valid_days} 天",
     "fromNotFound": "未找到可转移目标，请检查！",
+    "sameCdk": "目标CDK不能与来源CDK相同",
     "transferTip": "转移后原CDK时长将归零，请确认操作"
   },
   "Component": {

--- a/src/app/[locale]/transfer/page.tsx
+++ b/src/app/[locale]/transfer/page.tsx
@@ -92,6 +92,12 @@ export default function Transmission() {
       return;
     }
 
+    if (cdk === fromCdk) {
+      setToCdkDescription(t("sameCdk"));
+      setToCdkValid(false);
+      return;
+    }
+
     const response = await fetch(`${CLIENT_BACKEND}/api/billing/order/query?cdk=${cdk}`);
     const { ec, msg, data } = await response.json();
     if (ec === 200) {


### PR DESCRIPTION
## Summary by Sourcery

防止在相同的 CDK 之间进行转账，并在源 CDK 与目标 CDK 相同时显示本地化的验证消息。

Bug Fixes（错误修复）:
- 阻止目标 CDK 与源 CDK 相同的转账尝试，并将该输入标记为无效。

Enhancements（功能增强）:
- 在英文和中文消息目录中新增“相同 CDK 转账”验证消息的本地化文案。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prevent transfers between identical CDKs and surface a localized validation message when the source and destination CDKs match.

Bug Fixes:
- Block transfer attempts where the destination CDK is the same as the source CDK and mark the input as invalid.

Enhancements:
- Add localized copy for the same-CDK transfer validation message in English and Chinese message catalogs.

</details>