### PR TITLE
feat: dashboard 更多功能！

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -257,6 +257,20 @@
     "monthlyAmount": "Monthly Revenue",
     "refundedCount": "(Refunded: {count} deals)",
     "refundedAmount": "(Refunded: {amount} RMB)",
+    "estimatedRevenue": "Estimated Revenue",
+    "estimatedRevenueDesc": "50% share after platform fees",
+    "clickToViewDetail": "(Click for details)",
+    "estimatedRevenueDetail": {
+      "platform": "Platform",
+      "feeRate": "Fee Rate",
+      "sales": "Sales",
+      "platformFee": "Platform Fee",
+      "received": "Received",
+      "dividend": "Dividend",
+      "shareRate": "Share Rate",
+      "total": "Total Estimated Revenue",
+      "disclaimer": "* Estimated based on current sales data for reference only. Actual revenue is subject to final settlement."
+    },
     "lineChart": {
       "toggleCount": "Click to switch to sales volume",
       "toggleAmount": "Click to switch to sales revenue",

--- a/messages/en.json
+++ b/messages/en.json
@@ -285,6 +285,7 @@
       "amount": "Revenue",
       "title": "Daily Sales Record"
     },
+    "resetFilter": "Reset All",
     "statChart": {
       "title": "7-Day Resource Stats",
       "request": "DAU",

--- a/messages/en.json
+++ b/messages/en.json
@@ -258,7 +258,6 @@
     "refundedCount": "(Refunded: {count} deals)",
     "refundedAmount": "(Refunded: {amount} RMB)",
     "estimatedRevenue": "Estimated Revenue",
-    "estimatedRevenueDesc": "50% share after platform fees",
     "clickToViewDetail": "(Click for details)",
     "estimatedRevenueDetail": {
       "platform": "Platform",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -252,7 +252,6 @@
     "refundedCount": "（已退款：{count}份）",
     "refundedAmount": "（已退款：{amount}元）",
     "estimatedRevenue": "预计收益",
-    "estimatedRevenueDesc": "扣除平台费后按50%分成",
     "clickToViewDetail": "（点击查看详情）",
     "estimatedRevenueDetail": {
       "platform": "平台",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -251,6 +251,20 @@
     "monthlyAmount": "月销售总额",
     "refundedCount": "（已退款：{count}份）",
     "refundedAmount": "（已退款：{amount}元）",
+    "estimatedRevenue": "预计收益",
+    "estimatedRevenueDesc": "扣除平台费后按50%分成",
+    "clickToViewDetail": "（点击查看详情）",
+    "estimatedRevenueDetail": {
+      "platform": "平台",
+      "feeRate": "费率",
+      "sales": "销售额",
+      "platformFee": "平台费用",
+      "received": "到账金额",
+      "dividend": "分成金额",
+      "shareRate": "分成比例",
+      "total": "预计收益合计",
+      "disclaimer": "* 以上数据基于当前销售记录预估，仅供参考，实际收益以最终结算账单为准。"
+    },
     "lineChart": {
       "toggleCount": "点击切换为销量",
       "toggleAmount": "点击切换为销售额",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -279,6 +279,7 @@
       "amount": "销售额",
       "title": "日销售记录"
     },
+    "resetFilter": "全部重置",
     "statChart": {
       "title": "7天资源统计",
       "request": "日活",

--- a/src/app/[locale]/dashboard/Revenue.tsx
+++ b/src/app/[locale]/dashboard/Revenue.tsx
@@ -2,7 +2,16 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { useTranslations } from "next-intl";
-import { Button, Card, Skeleton, Tab, Tabs } from "@heroui/react";
+import {
+  Button,
+  Card,
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+  Skeleton,
+  Tab,
+  Tabs,
+} from "@heroui/react";
 import { debounce } from "lodash";
 import { Cell, Legend, Pie, PieChart, ResponsiveContainer, Tooltip, TooltipProps } from "recharts";
 import { Props } from "recharts/types/component/DefaultLegendContent";
@@ -82,6 +91,60 @@ export default function Revenue({ revenueData, statData, onLogOut, rid, date }: 
   const sourceData = useMemo(() => {
     const data = prepareChartData(revenueData, "source");
     return calculatePercentages(data);
+  }, [revenueData]);
+
+  const PLATFORM_FEE_RATES: Record<string, number> = {
+    yimapay: 0.02,
+    afdian: 0.06,
+    weixin: 0.01,
+    alipay: 0.006,
+  };
+
+  const PLATFORM_LABELS: Record<string, string> = {
+    yimapay: "易码付",
+    afdian: "爱发电",
+    weixin: "微信",
+    alipay: "支付宝",
+  };
+
+  const estimatedRevenue = useMemo(() => {
+    const platformMap: Record<
+      string,
+      { amount: number; fee: number; received: number; dividend: number; feeRate: number }
+    > = {};
+
+    revenueData.forEach(item => {
+      if (item.blocked) return;
+
+      const platform = item.platform;
+      const amount = parseFloat(item.amount);
+      const feeRate = PLATFORM_FEE_RATES[platform] ?? 0;
+
+      if (!platformMap[platform]) {
+        platformMap[platform] = { amount: 0, fee: 0, received: 0, dividend: 0, feeRate };
+      }
+
+      platformMap[platform].amount += amount;
+      platformMap[platform].fee += amount * feeRate;
+      platformMap[platform].received += amount * (1 - feeRate);
+      platformMap[platform].dividend += amount * (1 - feeRate) * 0.5;
+    });
+
+    const platforms = Object.entries(platformMap)
+      .map(([name, d]) => ({
+        name,
+        label: PLATFORM_LABELS[name] || name,
+        amount: parseFloat(d.amount.toFixed(2)),
+        fee: parseFloat(d.fee.toFixed(2)),
+        received: parseFloat(d.received.toFixed(2)),
+        dividend: parseFloat(d.dividend.toFixed(2)),
+        feeRate: d.feeRate,
+      }))
+      .sort((a, b) => b.amount - a.amount);
+
+    const total = parseFloat(platforms.reduce((sum, d) => sum + d.dividend, 0).toFixed(2));
+
+    return { platforms, total };
   }, [revenueData]);
 
   function calculatePercentages(data: ChartDataItem[]): ChartDataItem[] {
@@ -255,20 +318,18 @@ export default function Revenue({ revenueData, statData, onLogOut, rid, date }: 
     return (
       <div className="mx-auto max-w-7xl space-y-8 p-6">
         <Skeleton className="h-20 w-1/2 rounded-lg" />
+        <div className="mb-6 grid grid-cols-1 gap-4 sm:grid-cols-3">
+          {[1, 2, 3].map((_, i) => (
+            <Skeleton key={i} className="h-20 rounded-lg" />
+          ))}
+        </div>
         <div className="mb-6 grid grid-cols-1 gap-6 lg:grid-cols-3">
-          <div className="lg:col-span-2">
-            <div className="mb-6 grid grid-cols-1 gap-4 sm:grid-cols-2">
-              {[1, 2].map((_, i) => (
-                <Skeleton key={i} className="h-20 rounded-lg" />
-              ))}
-            </div>
-            <div className="mb-6 grid grid-cols-1 gap-6 sm:grid-cols-1 md:grid-cols-2">
-              {[1, 2, 3, 4].map((_, i) => (
-                <Skeleton key={i} className="h-60 rounded-lg" />
-              ))}
-            </div>
+          <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:col-span-2">
+            {[1, 2, 3, 4].map((_, i) => (
+              <Skeleton key={i} className="h-60 rounded-lg" />
+            ))}
           </div>
-          <Skeleton className="mb-6 min-h-96 rounded-lg lg:col-span-1" />
+          <Skeleton className="min-h-96 rounded-lg lg:col-span-1" />
         </div>
         <Skeleton className="h-96 rounded-lg" />
       </div>
@@ -312,66 +373,141 @@ export default function Revenue({ revenueData, statData, onLogOut, rid, date }: 
           <StatLineChartCard statData={statData} />
         ) : (
           <>
-            <div className="mb-6 grid grid-cols-1 gap-6 lg:grid-cols-3">
-              <div className="mx-auto w-full max-w-7xl lg:col-span-2">
-                {/* Stats cards */}
-                <div className="mb-6 grid grid-cols-1 gap-4 sm:grid-cols-2">
-                  <Card>
+            {/* Stats cards */}
+            <div className="mb-6 grid grid-cols-1 gap-4 sm:grid-cols-3">
+              <Card>
+                <div className="p-4 sm:p-8">
+                  <h3 className="text-gray-500">{t("monthlyCount")}</h3>
+                  <p className="text-2xl font-bold sm:text-3xl">
+                    {totalCount}
+                    {t("unit.count")}
+                    {refundedCount > 0 ? (
+                      <span className="ml-2 text-sm font-normal text-gray-500">
+                        {t("refundedCount", { count: refundedCount })}
+                      </span>
+                    ) : null}
+                  </p>
+                </div>
+              </Card>
+              <Card>
+                <div className="p-4 sm:p-8">
+                  <h3 className="text-gray-500">{t("monthlyAmount")}</h3>
+                  <p className="text-2xl font-bold sm:text-3xl">
+                    {totalAmount.toFixed(2)}
+                    {t("unit.amount")}
+                    {refundedAmount > 0 ? (
+                      <span className="ml-2 text-sm font-normal text-gray-500">
+                        {t("refundedAmount", { amount: refundedAmount.toFixed(2) })}
+                      </span>
+                    ) : null}
+                  </p>
+                </div>
+              </Card>
+              <Popover placement="bottom" showArrow>
+                <PopoverTrigger>
+                  <Card isPressable className="text-left">
                     <div className="p-4 sm:p-8">
-                      <h3 className="text-gray-500">{t("monthlyCount")}</h3>
-                      <p className="text-2xl font-bold sm:text-3xl">
-                        {totalCount}
-                        {t("unit.count")}
-                        {refundedCount > 0 ? (
-                          <span className="ml-2 text-sm font-normal text-gray-500">
-                            {t("refundedCount", { count: refundedCount })}
-                          </span>
-                        ) : null}
-                      </p>
-                    </div>
-                  </Card>
-                  <Card>
-                    <div className="p-4 sm:p-8">
-                      <h3 className="text-gray-500">{t("monthlyAmount")}</h3>
-                      <p className="text-2xl font-bold sm:text-3xl">
-                        {totalAmount.toFixed(2)}
+                      <h3 className="!text-gray-500">{t("estimatedRevenue")}</h3>
+                      <p className="!text-foreground text-2xl !font-bold sm:text-3xl">
+                        {estimatedRevenue.total.toFixed(2)}
                         {t("unit.amount")}
-                        {refundedAmount > 0 ? (
-                          <span className="ml-2 text-sm font-normal text-gray-500">
-                            {t("refundedAmount", { amount: refundedAmount.toFixed(2) })}
-                          </span>
-                        ) : null}
+                        <span className="ml-2 text-sm font-normal text-gray-500">
+                          {t("clickToViewDetail")}
+                        </span>
                       </p>
                     </div>
                   </Card>
-                </div>
+                </PopoverTrigger>
+                <PopoverContent>
+                  <div className="p-3">
+                    <table className="text-sm">
+                      <thead>
+                        <tr className="border-b text-left text-gray-500 dark:text-gray-400">
+                          <th className="pr-4 pb-2">{t("estimatedRevenueDetail.platform")}</th>
+                          <th className="pr-4 pb-2">{t("estimatedRevenueDetail.feeRate")}</th>
+                          <th className="pr-4 pb-2 text-right">
+                            {t("estimatedRevenueDetail.sales")}
+                          </th>
+                          <th className="pr-4 pb-2 text-right">
+                            {t("estimatedRevenueDetail.platformFee")}
+                          </th>
+                          <th className="pr-4 pb-2 text-right">
+                            {t("estimatedRevenueDetail.received")}
+                          </th>
+                          <th className="pr-4 pb-2">{t("estimatedRevenueDetail.shareRate")}</th>
+                          <th className="pb-2 text-right">
+                            {t("estimatedRevenueDetail.dividend")}
+                          </th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {estimatedRevenue.platforms.map(p => (
+                          <tr
+                            key={p.name}
+                            className="border-b border-gray-100 dark:border-gray-700"
+                          >
+                            <td className="py-2 pr-4 font-medium">{p.label}</td>
+                            <td className="py-2 pr-4 text-gray-500">
+                              {(p.feeRate * 100).toFixed(1)}%
+                            </td>
+                            <td className="py-2 pr-4 text-right">{p.amount.toFixed(2)}</td>
+                            <td className="py-2 pr-4 text-right text-red-500">
+                              -{p.fee.toFixed(2)}
+                            </td>
+                            <td className="py-2 pr-4 text-right">{p.received.toFixed(2)}</td>
+                            <td className="py-2 pr-4 text-center text-gray-500">50%</td>
+                            <td className="py-2 text-right font-medium text-green-600 dark:text-green-400">
+                              {p.dividend.toFixed(2)}
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                      <tfoot>
+                        <tr className="font-bold">
+                          <td className="pt-2" colSpan={6}>
+                            {t("estimatedRevenueDetail.total")}
+                          </td>
+                          <td className="pt-2 text-right text-green-600 dark:text-green-400">
+                            {estimatedRevenue.total.toFixed(2)}
+                            {t("unit.amount")}
+                          </td>
+                        </tr>
+                      </tfoot>
+                    </table>
+                    <p className="mt-3 border-t border-gray-200 pt-2 text-xs text-gray-400 dark:border-gray-700">
+                      {t("estimatedRevenueDetail.disclaimer")}
+                    </p>
+                  </div>
+                </PopoverContent>
+              </Popover>
+            </div>
 
-                {/* Chart section */}
-                <div className="mb-6 grid grid-cols-1 gap-6 sm:grid-cols-1 md:grid-cols-2">
-                  <Card>
-                    <div className="p-2">
-                      <SalesPieChart data={applicationData} title={t("application")} />
-                    </div>
-                  </Card>
-                  <Card>
-                    <div className="p-2">
-                      <SalesPieChart data={planData} title={t("plan")} />
-                    </div>
-                  </Card>
-                  <Card>
-                    <div className="p-2">
-                      <SalesPieChart data={userAgentData} title={t("userAgent")} />
-                    </div>
-                  </Card>
-                  <Card>
-                    <div className="p-2">
-                      <SalesPieChart data={sourceData} title={t("source")} />
-                    </div>
-                  </Card>
-                </div>
+            {/* Charts + Sales list */}
+            <div className="mb-6 grid grid-cols-1 gap-6 lg:grid-cols-3">
+              <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:col-span-2">
+                <Card>
+                  <div className="p-2">
+                    <SalesPieChart data={applicationData} title={t("application")} />
+                  </div>
+                </Card>
+                <Card>
+                  <div className="p-2">
+                    <SalesPieChart data={planData} title={t("plan")} />
+                  </div>
+                </Card>
+                <Card>
+                  <div className="p-2">
+                    <SalesPieChart data={userAgentData} title={t("userAgent")} />
+                  </div>
+                </Card>
+                <Card>
+                  <div className="p-2">
+                    <SalesPieChart data={sourceData} title={t("source")} />
+                  </div>
+                </Card>
               </div>
-              <Card className="mb-6 lg:col-span-1">
-                <div className="flex h-96 flex-col p-4 lg:h-[48.01rem]">
+              <Card className="lg:col-span-1">
+                <div className="flex h-96 flex-col p-4 lg:h-full">
                   <h3>{t("list.title")}</h3>
                   <div className="custom-scrollbar flex-1 overflow-y-auto">
                     <SalesList listData={revenueData} date={date} />

--- a/src/app/[locale]/dashboard/Revenue.tsx
+++ b/src/app/[locale]/dashboard/Revenue.tsx
@@ -20,6 +20,11 @@ import { RevenueType, StatData } from "@/app/[locale]/dashboard/page";
 import SalesList from "@/app/[locale]/dashboard/SalesList";
 import SalesLineChart from "@/app/[locale]/dashboard/SalesLineChart";
 import StatLineChartCard from "@/app/[locale]/dashboard/StatLineChartCard";
+import {
+  formatDashboardDayKeyFromDate,
+  getDashboardMonth,
+  parseDashboardAmount,
+} from "@/app/[locale]/dashboard/utils";
 
 type RevenueProps = {
   date: string;
@@ -45,6 +50,26 @@ type SalesPieChartProps = {
   title: string;
 };
 
+type LegendPayloadEntry = {
+  color?: string;
+  payload: ChartDataItem;
+  value: string;
+};
+
+const PLATFORM_FEE_RATES: Record<string, number> = {
+  yimapay: 0.02,
+  afdian: 0.06,
+  weixin: 0.01,
+  alipay: 0.006,
+};
+
+const PLATFORM_LABELS: Record<string, string> = {
+  yimapay: "易码付",
+  afdian: "爱发电",
+  weixin: "微信",
+  alipay: "支付宝",
+};
+
 export default function Revenue({ revenueData, statData, onLogOut, rid, date }: RevenueProps) {
   const t = useTranslations("Dashboard");
   const [isLoading, setIsLoading] = useState<boolean>(true);
@@ -52,6 +77,8 @@ export default function Revenue({ revenueData, statData, onLogOut, rid, date }: 
   const [filters, setFilters] = useState<FilterMap>({});
   const [filterDate, setFilterDate] = useState<string | null>(null);
   const hasFilters = Object.keys(filters).length > 0 || filterDate !== null;
+  const isSalesTab = activeTab === "sales";
+  const targetMonth = getDashboardMonth(date);
 
   const FILTER_FIELD_LABELS: Record<FilterField, string> = {
     application: t("application"),
@@ -93,21 +120,19 @@ export default function Revenue({ revenueData, statData, onLogOut, rid, date }: 
     }
 
     if (filterDate) {
-      const targetMonth = Number(date.slice(4));
       data = data.filter(item => {
-        const d = new Date(item.activated_at);
-        return `${targetMonth}-${d.getDate()}` === filterDate;
+        return formatDashboardDayKeyFromDate(item.activated_at, targetMonth) === filterDate;
       });
     }
 
     return data;
-  }, [revenueData, filters, filterDate, date]);
+  }, [revenueData, filters, filterDate, targetMonth]);
 
   const { totalCount, totalAmount, refundedCount, refundedAmount } = useMemo(() => {
     return filteredData.reduce(
       (acc, cur) => {
         const buyCount = Number(cur.buy_count) || 0;
-        const amount = Number(cur.amount) || 0;
+        const amount = parseDashboardAmount(cur.amount);
 
         acc.totalCount += buyCount;
         acc.totalAmount += amount;
@@ -124,12 +149,16 @@ export default function Revenue({ revenueData, statData, onLogOut, rid, date }: 
   }, [filteredData]);
   useEffect(() => {
     if (!revenueData) {
-      return onLogOut();
+      onLogOut();
+      return;
     }
-    setTimeout(() => {
+
+    const timeoutId = window.setTimeout(() => {
       setIsLoading(false);
     }, 1000);
-  }, []);
+
+    return () => window.clearTimeout(timeoutId);
+  }, [onLogOut, revenueData]);
 
   // Prepare chart data
   const applicationData = useMemo(() => {
@@ -152,20 +181,6 @@ export default function Revenue({ revenueData, statData, onLogOut, rid, date }: 
     return calculatePercentages(data);
   }, [filteredData]);
 
-  const PLATFORM_FEE_RATES: Record<string, number> = {
-    yimapay: 0.02,
-    afdian: 0.06,
-    weixin: 0.01,
-    alipay: 0.006,
-  };
-
-  const PLATFORM_LABELS: Record<string, string> = {
-    yimapay: "易码付",
-    afdian: "爱发电",
-    weixin: "微信",
-    alipay: "支付宝",
-  };
-
   const estimatedRevenue = useMemo(() => {
     const platformMap: Record<
       string,
@@ -176,7 +191,7 @@ export default function Revenue({ revenueData, statData, onLogOut, rid, date }: 
       if (item.blocked) return;
 
       const platform = item.platform;
-      const amount = parseFloat(item.amount);
+      const amount = parseDashboardAmount(item.amount);
       const feeRate = PLATFORM_FEE_RATES[platform] ?? 0;
 
       if (!platformMap[platform]) {
@@ -229,7 +244,7 @@ export default function Revenue({ revenueData, statData, onLogOut, rid, date }: 
     const grouped: Record<string, { amount: number; count: number }> = data.reduce(
       (acc, item) => {
         const keyValue = String(item[key]);
-        const amount = parseFloat(item.amount);
+        const amount = parseDashboardAmount(item.amount);
         const count = Number(item.buy_count);
 
         if (!acc[keyValue]) {
@@ -308,34 +323,40 @@ export default function Revenue({ revenueData, statData, onLogOut, rid, date }: 
 
     const legendContent = ({ payload }: Props) => {
       if (!payload) return null;
+
+      const legendEntries = payload as unknown as LegendPayloadEntry[];
+
       return (
         <ul className="text-xs">
-          {payload.map((entry: any, index: number) => {
+          {legendEntries.map((entry, index) => {
             const isActive = activeValue === entry.value;
             return (
-              <li
-                key={`item-${index}`}
-                className={`mb-1 flex cursor-pointer items-center rounded px-1 py-0.5 transition-colors hover:bg-gray-100 dark:hover:bg-gray-700 ${
-                  isActive
-                    ? "bg-blue-100 ring-1 ring-blue-300 dark:bg-blue-900/30 dark:ring-blue-700"
-                    : ""
-                }`}
-                onClick={() => handleFilterToggle(pieChartProps.field, entry.value)}
-              >
-                <span
-                  className="mr-1 inline-block h-3 w-3 shrink-0"
-                  style={{ backgroundColor: entry.color }}
-                />
-                <div className="flex flex-col">
-                  <span>
-                    {entry.value} {entry.payload.percentage}%{" "}
-                  </span>
-                  <span className="text-gray-500">
-                    {entry.payload.count}
-                    {t("unit.count")} {entry.payload.amount.toFixed(2)}
-                    {t("unit.amount")}
-                  </span>
-                </div>
+              <li key={`item-${index}`} className="mb-1">
+                <button
+                  type="button"
+                  className={`flex w-full items-center rounded px-1 py-0.5 text-left transition-colors hover:bg-gray-100 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none dark:hover:bg-gray-700 ${
+                    isActive
+                      ? "bg-blue-100 ring-1 ring-blue-300 dark:bg-blue-900/30 dark:ring-blue-700"
+                      : ""
+                  }`}
+                  onClick={() => handleFilterToggle(pieChartProps.field, entry.value)}
+                  aria-pressed={isActive}
+                >
+                  <span
+                    className="mr-1 inline-block h-3 w-3 shrink-0"
+                    style={{ backgroundColor: entry.color }}
+                  />
+                  <div className="flex flex-col">
+                    <span>
+                      {entry.value} {entry.payload.percentage}%{" "}
+                    </span>
+                    <span className="text-gray-500">
+                      {entry.payload.count}
+                      {t("unit.count")} {entry.payload.amount.toFixed(2)}
+                      {t("unit.amount")}
+                    </span>
+                  </div>
+                </button>
               </li>
             );
           })}
@@ -437,18 +458,20 @@ export default function Revenue({ revenueData, statData, onLogOut, rid, date }: 
                 <Tab key="stat" title={t("statChart.title")} />
               </Tabs>
             ) : null}
-            <Button
-              className="w-full sm:w-auto"
-              color="secondary"
-              variant="ghost"
-              onClick={handleExport}
-            >
-              {t("export")}
-            </Button>
+            {isSalesTab ? (
+              <Button
+                className="w-full sm:w-auto"
+                color="secondary"
+                variant="ghost"
+                onClick={handleExport}
+              >
+                {t("export")}
+              </Button>
+            ) : null}
           </div>
         </div>
 
-        {hasFilters && (
+        {isSalesTab && hasFilters && (
           <div className="mb-4 flex flex-wrap items-center gap-2">
             {(Object.entries(filters) as [FilterField, string][]).map(([field, value]) => (
               <Chip key={field} variant="flat" color="primary" onClose={() => removeFilter(field)}>

--- a/src/app/[locale]/dashboard/Revenue.tsx
+++ b/src/app/[locale]/dashboard/Revenue.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslations } from "next-intl";
 import {
   Button,
   Card,
+  Chip,
   Popover,
   PopoverContent,
   PopoverTrigger,
@@ -35,8 +36,12 @@ type ChartDataItem = {
   percentage?: number;
 };
 
+type FilterField = "application" | "plan" | "user_agent" | "source";
+type FilterMap = Partial<Record<FilterField, string>>;
+
 type SalesPieChartProps = {
   data: ChartDataItem[];
+  field: FilterField;
   title: string;
 };
 
@@ -44,8 +49,62 @@ export default function Revenue({ revenueData, statData, onLogOut, rid, date }: 
   const t = useTranslations("Dashboard");
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [activeTab, setActiveTab] = useState<string>("sales");
+  const [filters, setFilters] = useState<FilterMap>({});
+  const [filterDate, setFilterDate] = useState<string | null>(null);
+  const hasFilters = Object.keys(filters).length > 0 || filterDate !== null;
+
+  const FILTER_FIELD_LABELS: Record<FilterField, string> = {
+    application: t("application"),
+    plan: t("plan"),
+    user_agent: t("userAgent"),
+    source: t("source"),
+  };
+
+  const handleFilterToggle = useCallback((field: FilterField, value: string) => {
+    setFilters(prev => {
+      const next = { ...prev };
+      if (next[field] === value) {
+        delete next[field];
+      } else {
+        next[field] = value;
+      }
+      return next;
+    });
+  }, []);
+
+  const removeFilter = useCallback((field: FilterField) => {
+    setFilters(prev => {
+      const next = { ...prev };
+      delete next[field];
+      return next;
+    });
+  }, []);
+
+  const handleDateFilterToggle = useCallback((dateStr: string) => {
+    setFilterDate(prev => (prev === dateStr ? null : dateStr));
+  }, []);
+
+  const filteredData = useMemo(() => {
+    let data = revenueData;
+
+    const entries = Object.entries(filters) as [FilterField, string][];
+    if (entries.length > 0) {
+      data = data.filter(item => entries.every(([field, value]) => String(item[field]) === value));
+    }
+
+    if (filterDate) {
+      const targetMonth = Number(date.slice(4));
+      data = data.filter(item => {
+        const d = new Date(item.activated_at);
+        return `${targetMonth}-${d.getDate()}` === filterDate;
+      });
+    }
+
+    return data;
+  }, [revenueData, filters, filterDate, date]);
+
   const { totalCount, totalAmount, refundedCount, refundedAmount } = useMemo(() => {
-    return revenueData.reduce(
+    return filteredData.reduce(
       (acc, cur) => {
         const buyCount = Number(cur.buy_count) || 0;
         const amount = Number(cur.amount) || 0;
@@ -62,7 +121,7 @@ export default function Revenue({ revenueData, statData, onLogOut, rid, date }: 
       },
       { totalCount: 0, totalAmount: 0, refundedCount: 0, refundedAmount: 0 }
     );
-  }, [revenueData]);
+  }, [filteredData]);
   useEffect(() => {
     if (!revenueData) {
       return onLogOut();
@@ -74,24 +133,24 @@ export default function Revenue({ revenueData, statData, onLogOut, rid, date }: 
 
   // Prepare chart data
   const applicationData = useMemo(() => {
-    const data = prepareChartData(revenueData, "application");
+    const data = prepareChartData(filteredData, "application");
     return calculatePercentages(data);
-  }, [revenueData]);
+  }, [filteredData]);
 
   const userAgentData = useMemo(() => {
-    const data = prepareChartData(revenueData, "user_agent");
+    const data = prepareChartData(filteredData, "user_agent");
     return calculatePercentages(data);
-  }, [revenueData]);
+  }, [filteredData]);
 
   const planData = useMemo(() => {
-    const data = prepareChartData(revenueData, "plan");
+    const data = prepareChartData(filteredData, "plan");
     return calculatePercentages(data);
-  }, [revenueData]);
+  }, [filteredData]);
 
   const sourceData = useMemo(() => {
-    const data = prepareChartData(revenueData, "source");
+    const data = prepareChartData(filteredData, "source");
     return calculatePercentages(data);
-  }, [revenueData]);
+  }, [filteredData]);
 
   const PLATFORM_FEE_RATES: Record<string, number> = {
     yimapay: 0.02,
@@ -113,7 +172,7 @@ export default function Revenue({ revenueData, statData, onLogOut, rid, date }: 
       { amount: number; fee: number; received: number; dividend: number; feeRate: number }
     > = {};
 
-    revenueData.forEach(item => {
+    filteredData.forEach(item => {
       if (item.blocked) return;
 
       const platform = item.platform;
@@ -145,7 +204,7 @@ export default function Revenue({ revenueData, statData, onLogOut, rid, date }: 
     const total = parseFloat(platforms.reduce((sum, d) => sum + d.dividend, 0).toFixed(2));
 
     return { platforms, total };
-  }, [revenueData]);
+  }, [filteredData]);
 
   function calculatePercentages(data: ChartDataItem[]): ChartDataItem[] {
     const total = data.reduce((sum, item) => sum + item.count, 0);
@@ -190,37 +249,13 @@ export default function Revenue({ revenueData, statData, onLogOut, rid, date }: 
     }));
   }
 
-  // Function to render legend for pie chart
-  const renderLegend = ({ payload }: Props) => {
-    if (!payload) return null;
-    return (
-      <ul className="text-xs">
-        {payload.map((entry: any, index: number) => (
-          <li key={`item-${index}`} className="mb-1 flex items-center">
-            <span className="mr-1 inline-block h-3 w-3" style={{ backgroundColor: entry.color }} />
-            <div className="flex flex-col">
-              <span>
-                {entry.value} {entry.payload.percentage}%{" "}
-              </span>
-              <span className="text-gray-500">
-                {entry.payload.count}
-                {t("unit.count")} {entry.payload.amount.toFixed(2)}
-                {t("unit.amount")}
-              </span>
-            </div>
-          </li>
-        ))}
-      </ul>
-    );
-  };
-
   // CSV export handler
   const handleExport = debounce(async () => {
     const filename = `MirrorChyan Sales ${rid} ${date}.csv`;
     const csvContent =
       "\uFEFF" +
       "activated_at,application,plan,user_agent,source,platform,amount,blocked\n" +
-      revenueData
+      filteredData
         .map(
           d =>
             `${d.activated_at},${d.application},${d.plan},${d.user_agent},${d.source},${d.platform},${d.amount},${d.blocked ? 1 : 0}`
@@ -249,6 +284,8 @@ export default function Revenue({ revenueData, statData, onLogOut, rid, date }: 
       "#20B2AA",
     ];
 
+    const activeValue = filters[pieChartProps.field];
+
     const customTooltip = (toolTipProps: TooltipProps<number, string>) => {
       const { active, payload } = toolTipProps;
       if (active && payload && payload.length) {
@@ -269,9 +306,51 @@ export default function Revenue({ revenueData, statData, onLogOut, rid, date }: 
       return null;
     };
 
+    const legendContent = ({ payload }: Props) => {
+      if (!payload) return null;
+      return (
+        <ul className="text-xs">
+          {payload.map((entry: any, index: number) => {
+            const isActive = activeValue === entry.value;
+            return (
+              <li
+                key={`item-${index}`}
+                className={`mb-1 flex cursor-pointer items-center rounded px-1 py-0.5 transition-colors hover:bg-gray-100 dark:hover:bg-gray-700 ${
+                  isActive
+                    ? "bg-blue-100 ring-1 ring-blue-300 dark:bg-blue-900/30 dark:ring-blue-700"
+                    : ""
+                }`}
+                onClick={() => handleFilterToggle(pieChartProps.field, entry.value)}
+              >
+                <span
+                  className="mr-1 inline-block h-3 w-3 shrink-0"
+                  style={{ backgroundColor: entry.color }}
+                />
+                <div className="flex flex-col">
+                  <span>
+                    {entry.value} {entry.payload.percentage}%{" "}
+                  </span>
+                  <span className="text-gray-500">
+                    {entry.payload.count}
+                    {t("unit.count")} {entry.payload.amount.toFixed(2)}
+                    {t("unit.amount")}
+                  </span>
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      );
+    };
+
     return (
       <div className="h-full">
-        <h3 className="mb-2">{pieChartProps.title}</h3>
+        <h3 className="mb-2">
+          {pieChartProps.title}
+          {activeValue && (
+            <span className="ml-2 text-sm font-normal text-blue-500">({activeValue})</span>
+          )}
+        </h3>
         <ResponsiveContainer width="100%" height={250}>
           <PieChart>
             <Pie
@@ -296,7 +375,7 @@ export default function Revenue({ revenueData, statData, onLogOut, rid, date }: 
               layout="vertical"
               align="left"
               verticalAlign="top"
-              content={renderLegend}
+              content={legendContent}
               wrapperStyle={{
                 maxHeight: "240px",
                 overflowY: "auto",
@@ -368,6 +447,32 @@ export default function Revenue({ revenueData, statData, onLogOut, rid, date }: 
             </Button>
           </div>
         </div>
+
+        {hasFilters && (
+          <div className="mb-4 flex flex-wrap items-center gap-2">
+            {(Object.entries(filters) as [FilterField, string][]).map(([field, value]) => (
+              <Chip key={field} variant="flat" color="primary" onClose={() => removeFilter(field)}>
+                {FILTER_FIELD_LABELS[field]}: {value}
+              </Chip>
+            ))}
+            {filterDate && (
+              <Chip variant="flat" color="secondary" onClose={() => setFilterDate(null)}>
+                {t("list.date")}: {filterDate}
+              </Chip>
+            )}
+            <Button
+              size="sm"
+              variant="light"
+              color="danger"
+              onClick={() => {
+                setFilters({});
+                setFilterDate(null);
+              }}
+            >
+              {t("resetFilter")}
+            </Button>
+          </div>
+        )}
 
         {activeTab === "stat" ? (
           <StatLineChartCard statData={statData} />
@@ -487,37 +592,53 @@ export default function Revenue({ revenueData, statData, onLogOut, rid, date }: 
               <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:col-span-2">
                 <Card>
                   <div className="p-2">
-                    <SalesPieChart data={applicationData} title={t("application")} />
+                    <SalesPieChart
+                      data={applicationData}
+                      field="application"
+                      title={t("application")}
+                    />
                   </div>
                 </Card>
                 <Card>
                   <div className="p-2">
-                    <SalesPieChart data={planData} title={t("plan")} />
+                    <SalesPieChart data={planData} field="plan" title={t("plan")} />
                   </div>
                 </Card>
                 <Card>
                   <div className="p-2">
-                    <SalesPieChart data={userAgentData} title={t("userAgent")} />
+                    <SalesPieChart data={userAgentData} field="user_agent" title={t("userAgent")} />
                   </div>
                 </Card>
                 <Card>
                   <div className="p-2">
-                    <SalesPieChart data={sourceData} title={t("source")} />
+                    <SalesPieChart data={sourceData} field="source" title={t("source")} />
                   </div>
                 </Card>
               </div>
               <Card className="lg:col-span-1">
                 <div className="flex h-96 flex-col p-4 lg:h-full">
-                  <h3>{t("list.title")}</h3>
+                  <h3>
+                    {t("list.title")}
+                    {filterDate && (
+                      <span className="text-secondary ml-2 text-sm font-normal">
+                        ({filterDate})
+                      </span>
+                    )}
+                  </h3>
                   <div className="custom-scrollbar flex-1 overflow-y-auto">
-                    <SalesList listData={revenueData} date={date} />
+                    <SalesList
+                      listData={filteredData}
+                      date={date}
+                      activeDate={filterDate}
+                      onDateClick={handleDateFilterToggle}
+                    />
                   </div>
                 </div>
               </Card>
             </div>
             <Card>
               <div className="h-96 w-full p-4 sm:h-80">
-                <SalesLineChart revenueData={revenueData} date={date} />
+                <SalesLineChart revenueData={filteredData} date={date} />
               </div>
             </Card>
           </>

--- a/src/app/[locale]/dashboard/SalesList.tsx
+++ b/src/app/[locale]/dashboard/SalesList.tsx
@@ -7,6 +7,8 @@ import { groupBy } from "lodash";
 type PropsType = {
   listData: RevenueType[];
   date: string;
+  activeDate?: string | null;
+  onDateClick?: (date: string) => void;
 };
 
 type DataType = {
@@ -37,7 +39,7 @@ const UpDownIcon = () => {
   );
 };
 
-export default function SalesList({ listData, date }: PropsType) {
+export default function SalesList({ listData, date, activeDate, onDateClick }: PropsType) {
   const t = useTranslations("Dashboard");
   const [sortBy, setSortBy] = useState<string>("date");
   const [sortOrder, setSortOrder] = useState<"asc" | "desc">("asc");
@@ -55,9 +57,7 @@ export default function SalesList({ listData, date }: PropsType) {
     const dates: number[] = [];
     // 只有当年份和月份都匹配当前时间时，才使用当前日期作为最后一天
     const lastDay =
-      currentYear === targetYear && currentMonth === targetMonth
-        ? now.getDate()
-        : daysInMonth;
+      currentYear === targetYear && currentMonth === targetMonth ? now.getDate() : daysInMonth;
 
     for (let i = 1; i <= lastDay; i++) {
       dates.push(i);
@@ -102,7 +102,8 @@ export default function SalesList({ listData, date }: PropsType) {
   }, [listData]);
 
   const processedData = useMemo(() => {
-    return [...resolveData].sort((a, b) => {
+    const data = activeDate ? resolveData.filter(d => d.date === activeDate) : resolveData;
+    return [...data].sort((a, b) => {
       if (sortBy === "date") {
         return Number(
           sortOrder === "asc"
@@ -117,7 +118,7 @@ export default function SalesList({ listData, date }: PropsType) {
         return sortOrder === "asc" ? a.count - b.count : b.count - a.count;
       }
     });
-  }, [resolveData, sortBy, sortOrder]);
+  }, [resolveData, sortBy, sortOrder, activeDate]);
 
   const columns = [
     {
@@ -157,7 +158,10 @@ export default function SalesList({ listData, date }: PropsType) {
           {item => (
             <TableRow
               key={String(item.date)}
-              className="hover:bg-gray-100 dark:text-white dark:hover:bg-gray-800"
+              className={`cursor-pointer transition-colors hover:bg-gray-100 dark:text-white dark:hover:bg-gray-800 ${
+                activeDate === item.date ? "bg-blue-50 dark:bg-blue-900/20" : ""
+              }`}
+              onClick={() => onDateClick?.(item.date)}
             >
               <TableCell className="text-center">{item.date}</TableCell>
               <TableCell className="text-center">{item.count}</TableCell>

--- a/src/app/[locale]/dashboard/SalesList.tsx
+++ b/src/app/[locale]/dashboard/SalesList.tsx
@@ -1,5 +1,11 @@
 import { Table, TableBody, TableCell, TableColumn, TableHeader, TableRow } from "@heroui/react";
 import { RevenueType } from "@/app/[locale]/dashboard/page";
+import {
+  formatDashboardDayKey,
+  formatDashboardDayKeyFromDate,
+  getDashboardMonth,
+  parseDashboardAmount,
+} from "@/app/[locale]/dashboard/utils";
 import { useTranslations } from "next-intl";
 import { useMemo, useState } from "react";
 import { groupBy } from "lodash";
@@ -43,8 +49,9 @@ export default function SalesList({ listData, date, activeDate, onDateClick }: P
   const t = useTranslations("Dashboard");
   const [sortBy, setSortBy] = useState<string>("date");
   const [sortOrder, setSortOrder] = useState<"asc" | "desc">("asc");
+  const targetMonth = getDashboardMonth(date);
 
-  const generateDateRange = () => {
+  const dateRange = useMemo(() => {
     const targetYear = Number(date.slice(0, 4));
     const targetMonth = Number(date.slice(4));
     // 使用 Date 对象计算该月的天数（月份传入下一个月，日期传0会回到上个月最后一天）
@@ -63,22 +70,21 @@ export default function SalesList({ listData, date, activeDate, onDateClick }: P
       dates.push(i);
     }
     return dates;
-  };
+  }, [date]);
 
   // 初始化日期范围
   const resolveData = useMemo(() => {
     const groupedData = groupBy(
       listData.map(item => ({
         ...item,
-        activated_at: `${Number(date.slice(4))}-${new Date(item.activated_at).getDate()}`,
+        activated_at: formatDashboardDayKeyFromDate(item.activated_at, targetMonth),
       })),
       item => item.activated_at
     );
     const dateMap = new Map<string, DataType>();
-    const dateRange = generateDateRange();
 
     dateRange.forEach(day => {
-      const key = `${Number(date.slice(4))}-${day}`;
+      const key = formatDashboardDayKey(targetMonth, day);
 
       if (groupedData[key] === undefined) {
         dateMap.set(key, {
@@ -89,7 +95,7 @@ export default function SalesList({ listData, date, activeDate, onDateClick }: P
       } else {
         const count = Number(groupedData[key].reduce((acc, cur) => acc + Number(cur.buy_count), 0));
         const amount = groupedData[key]
-          .reduce((acc, cur) => acc + Number(cur.amount), 0)
+          .reduce((acc, cur) => acc + parseDashboardAmount(cur.amount), 0)
           .toFixed(2);
         dateMap.set(key, {
           count,
@@ -99,17 +105,13 @@ export default function SalesList({ listData, date, activeDate, onDateClick }: P
       }
     });
     return Array.from(dateMap.values());
-  }, [listData]);
+  }, [dateRange, listData, targetMonth]);
 
   const processedData = useMemo(() => {
     const data = activeDate ? resolveData.filter(d => d.date === activeDate) : resolveData;
     return [...data].sort((a, b) => {
       if (sortBy === "date") {
-        return Number(
-          sortOrder === "asc"
-            ? Number(new Date(a.date)) - Number(new Date(b.date))
-            : Number(new Date(b.date)) - Number(new Date(a.date))
-        );
+        return sortOrder === "asc" ? a.date.localeCompare(b.date) : b.date.localeCompare(a.date);
       } else if (sortBy === "amount") {
         return sortOrder === "asc"
           ? Number(a.amount) - Number(b.amount)
@@ -137,12 +139,20 @@ export default function SalesList({ listData, date, activeDate, onDateClick }: P
 
   return (
     <>
-      <Table isVirtualized isHeaderSticky className="scrollbar-hide h-full overflow-y-scroll p-0">
+      <Table
+        isVirtualized
+        isHeaderSticky
+        aria-label={t("list.title")}
+        onRowAction={onDateClick ? key => onDateClick(String(key)) : undefined}
+        className="scrollbar-hide h-full overflow-y-scroll p-0"
+      >
         <TableHeader columns={columns} className="relative">
           {column => (
             <TableColumn key={column.key} className="relative text-center">
               {column.label}
-              <div
+              <button
+                type="button"
+                aria-label={String(column.label)}
                 onClick={() => {
                   setSortBy(column.key);
                   setSortOrder(sortOrder === "asc" ? "desc" : "asc");
@@ -150,7 +160,7 @@ export default function SalesList({ listData, date, activeDate, onDateClick }: P
                 className="absolute top-1 right-0 mt-2 mr-2 cursor-pointer transition hover:rotate-180 hover:text-gray-400 hover:shadow-sm"
               >
                 <UpDownIcon />
-              </div>
+              </button>
             </TableColumn>
           )}
         </TableHeader>
@@ -158,10 +168,9 @@ export default function SalesList({ listData, date, activeDate, onDateClick }: P
           {item => (
             <TableRow
               key={String(item.date)}
-              className={`cursor-pointer transition-colors hover:bg-gray-100 dark:text-white dark:hover:bg-gray-800 ${
+              className={`${onDateClick ? "cursor-pointer" : ""} transition-colors hover:bg-gray-100 dark:text-white dark:hover:bg-gray-800 ${
                 activeDate === item.date ? "bg-blue-50 dark:bg-blue-900/20" : ""
               }`}
-              onClick={() => onDateClick?.(item.date)}
             >
               <TableCell className="text-center">{item.date}</TableCell>
               <TableCell className="text-center">{item.count}</TableCell>

--- a/src/app/[locale]/dashboard/utils.ts
+++ b/src/app/[locale]/dashboard/utils.ts
@@ -1,0 +1,22 @@
+export function getDashboardMonth(value: string) {
+  return value.slice(4).padStart(2, "0");
+}
+
+export function formatDashboardDayKey(month: string | number, day: string | number) {
+  return `${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
+}
+
+export function formatDashboardDayKeyFromDate(value: Date | string, month: string | number) {
+  const parsedDate = new Date(value);
+
+  if (Number.isNaN(parsedDate.getTime())) {
+    return "";
+  }
+
+  return formatDashboardDayKey(month, parsedDate.getDate());
+}
+
+export function parseDashboardAmount(value: unknown) {
+  const amount = Number(value);
+  return Number.isFinite(amount) ? amount : 0;
+}


### PR DESCRIPTION
## Summary by Sourcery

在仪表板的收入视图中添加交互式筛选和预估收入计算功能。

新功能：
- 允许从图表和销售列表中按应用、方案、用户代理、来源以及特定日期筛选收入数据。
- 在收入仪表板中以可移除的标签形式显示当前启用的筛选条件，并提供重置选项。
- 在弹出层中显示预估收入卡片，包括按平台拆分的明细、手续费以及分成计算。
- 支持通过点击饼图图例和销售列表行来驱动当前启用的筛选条件和选定日期。

增强内容：
- 将所有仪表板统计数据、图表以及 CSV 导出操作应用到“已筛选”的收入数据集，而非原始数据。
- 优化仪表板的加载骨架屏，以及统计信息、图表和销售列表的布局，以提升可读性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add interactive filtering and estimated revenue calculations to the dashboard revenue view.

New Features:
- Allow filtering revenue data by application, plan, user agent, source, and specific dates from charts and sales list.
- Display active filters as removable chips with a reset option in the revenue dashboard.
- Show an estimated revenue card with per-platform breakdown, fees, and share calculations in a popover.
- Enable clicking pie chart legends and sales list rows to drive the active filters and selected date.

Enhancements:
- Apply all dashboard statistics, charts, and CSV export operations to the filtered revenue dataset instead of the raw data.
- Refine the dashboard loading skeletons and layout of stats, charts, and sales list for better readability.

</details>