### PR TITLE
Release 20260404-1

### DIFF
--- a/src/app/[locale]/dashboard/StatLineChart.tsx
+++ b/src/app/[locale]/dashboard/StatLineChart.tsx
@@ -68,11 +68,15 @@ export default function StatLineChart({ statData }: Props) {
     return (
       <div className="rounded border bg-white p-3 shadow-lg dark:border-gray-700 dark:bg-gray-800">
         <p className="mb-1 font-medium dark:text-white">{label}</p>
-        {payload.map((entry, i) => (
-          <p key={i} style={{ color: entry.color }} className="text-sm">
-            {entry.name}: {(entry.value as number).toLocaleString()}
-          </p>
-        ))}
+        <div className="max-h-48 overflow-y-auto [&::-webkit-scrollbar]:w-1 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-gray-300 dark:[&::-webkit-scrollbar-thumb]:bg-gray-600">
+          {[...payload]
+            .sort((a, b) => (b.value as number) - (a.value as number))
+            .map((entry, i) => (
+              <p key={i} style={{ color: entry.color }} className="text-sm">
+                {entry.name}: {(entry.value as number).toLocaleString()}
+              </p>
+            ))}
+        </div>
       </div>
     );
   };
@@ -97,7 +101,7 @@ export default function StatLineChart({ statData }: Props) {
             tickLine={{ stroke: "#ccc" }}
             domain={[0, (dataMax: number) => Math.ceil(dataMax * 1.1)]}
           />
-          <Tooltip content={<CustomTooltip />} />
+          <Tooltip content={<CustomTooltip />} wrapperStyle={{ pointerEvents: "auto" }} />
           {rids.map((rid, i) => (
             <Line
               key={rid}


### PR DESCRIPTION
fix: 优化 dashboard 资源统计折线图 tooltip 面板

## Summary by Sourcery

改进仪表盘统计折线图的提示框，以提升可读性和交互体验。

Bug 修复：
- 通过在提示框包裹元素上启用指针事件，允许用户在仪表盘统计折线图的提示框内进行滚动。

增强功能：
- 将仪表盘统计折线图中提示框条目按数值降序排序，并在带有自定义滚动条样式的可滚动面板中展示。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve the dashboard statistics line chart tooltip for better readability and interaction.

Bug Fixes:
- Allow users to scroll within the dashboard statistics line chart tooltip by enabling pointer events on the tooltip wrapper.

Enhancements:
- Sort tooltip entries in the dashboard statistics line chart in descending order by value and display them in a scrollable panel with custom scrollbar styling.

</details>