### PR TITLE
Release 20260406

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -276,7 +276,7 @@
       "labelAmount": "Revenue (RMB)",
       "slide": "← Slide to see the full chart →",
       "labelCount": "Sales (deals)",
-      "title": "Sales Line Chart"
+      "title": "Sales Stats"
     },
     "list": {
       "date": "Date",
@@ -286,7 +286,7 @@
     },
     "resetFilter": "Reset All",
     "statChart": {
-      "title": "7-Day Resource Stats",
+      "title": "Requests Stats",
       "request": "DAU",
       "count": "Downloads",
       "toggleCount": "Switch to Downloads",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -270,7 +270,7 @@
       "labelAmount": "销售额 (元)",
       "slide": "← 左右滑动查看完整图表 →",
       "labelCount": "销量 (份)",
-      "title": "销售额/销量折线图"
+      "title": "销售统计"
     },
     "list": {
       "date": "日期",
@@ -280,7 +280,7 @@
     },
     "resetFilter": "全部重置",
     "statChart": {
-      "title": "7天资源统计",
+      "title": "请求统计",
       "request": "日活",
       "count": "下载量",
       "toggleCount": "切换为下载量",

--- a/src/app/[locale]/dashboard/Revenue.tsx
+++ b/src/app/[locale]/dashboard/Revenue.tsx
@@ -447,6 +447,16 @@ export default function Revenue({ revenueData, statData, onLogOut, rid, date }: 
             {t("dashboardTitle", { rid, date })}
           </h1>
           <div className="flex w-full items-center gap-3 sm:mr-8 sm:w-auto">
+            {isSalesTab ? (
+              <Button
+                className="w-full sm:w-auto"
+                color="secondary"
+                variant="ghost"
+                onClick={handleExport}
+              >
+                {t("export")}
+              </Button>
+            ) : null}
             {hasStatData ? (
               <Tabs
                 selectedKey={activeTab}
@@ -457,16 +467,6 @@ export default function Revenue({ revenueData, statData, onLogOut, rid, date }: 
                 <Tab key="sales" title={t("lineChart.title")} />
                 <Tab key="stat" title={t("statChart.title")} />
               </Tabs>
-            ) : null}
-            {isSalesTab ? (
-              <Button
-                className="w-full sm:w-auto"
-                color="secondary"
-                variant="ghost"
-                onClick={handleExport}
-              >
-                {t("export")}
-              </Button>
             ) : null}
           </div>
         </div>

--- a/src/components/LanguageSwitcher.tsx
+++ b/src/components/LanguageSwitcher.tsx
@@ -19,10 +19,6 @@ export default function LanguageSwitcher() {
     setMounted(true);
   }, []);
 
-  useEffect(() => {
-    router.prefetch(pathname, { locale: otherLocale });
-  }, [pathname, otherLocale, router]);
-
   const toggleLocale = () => {
     startTransition(() => {
       router.replace(pathname, { locale: otherLocale });

--- a/src/components/LanguageSwitcher.tsx
+++ b/src/components/LanguageSwitcher.tsx
@@ -1,11 +1,9 @@
 "use client";
 
-import { useTransition, useEffect, useState } from "react";
+import { useEffect, useState, useTransition } from "react";
 import { createPortal } from "react-dom";
 import { useLocale } from "next-intl";
-import { useRouter, usePathname } from "@/i18n/routing";
-
-const LOCALE_STORAGE_KEY = "preferred-locale";
+import { usePathname, useRouter } from "@/i18n/routing";
 
 export default function LanguageSwitcher() {
   const locale = useLocale();
@@ -21,20 +19,11 @@ export default function LanguageSwitcher() {
     setMounted(true);
   }, []);
 
-  // 首次访问时，如果 localStorage 中有存储的语言偏好且与当前不同，自动切换
-  useEffect(() => {
-    const stored = localStorage.getItem(LOCALE_STORAGE_KEY);
-    if (stored && stored !== locale && (stored === "zh" || stored === "en")) {
-      router.replace(pathname, { locale: stored });
-    }
-  }, []);
-
   useEffect(() => {
     router.prefetch(pathname, { locale: otherLocale });
   }, [pathname, otherLocale, router]);
 
   const toggleLocale = () => {
-    localStorage.setItem(LOCALE_STORAGE_KEY, otherLocale);
     startTransition(() => {
       router.replace(pathname, { locale: otherLocale });
     });

--- a/src/i18n/routing.ts
+++ b/src/i18n/routing.ts
@@ -10,6 +10,9 @@ export const routing = defineRouting({
   // Used when no locale matches
   defaultLocale: "en",
   localePrefix: "always",
+  localeCookie: {
+    maxAge: 60 * 60 * 24 * 365,
+  },
 });
 
 // Lightweight wrappers around Next.js' navigation APIs


### PR DESCRIPTION
## Summary by Sourcery

通过路由 cookies 持久化用户的语言偏好，并调整仪表盘导出按钮的位置。

改进内容：
- 将营收仪表盘顶部的销售导出按钮移动到统计/销售标签页切换器之前，以提升布局一致性。
- 用在 i18n 路由层配置的、由服务器管理的语言 cookies 替代客户端 `localStorage` 的本地语言持久化方式。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Persist users' language preference via routing cookies and adjust the dashboard export button placement.

Enhancements:
- Move the sales export button before the stats/sales tab switcher on the revenue dashboard header for improved layout consistency.
- Replace client-side localStorage locale persistence with server-managed locale cookies configured in the i18n routing layer.

</details>