### PR TITLE
Release 20260528

### DIFF
--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -129,23 +129,26 @@ export default function ProjectCard(props: ProjectCardProps) {
     }));
   }, [channel, supportOptions]);
 
+  const renderFixedSelect = (value: any[]) => {
+    return !(value.length === 0 || (value.length === 1 && value[0].value === "any"));
+  };
+
   const availableArch = useMemo(() => {
-    if (!channel || !os) return [];
+    if (!channel) return [];
+    // OS 全为 "any" 时 os 状态保持空字符串，此时用 "any" 作为过滤值
+    const effectiveOs = !renderFixedSelect(availableOS) ? "any" : os;
+    if (!effectiveOs) return [];
     return [
       ...new Set(
         supportOptions
-          .filter(item => item.channel === channel && item.os === os)
+          .filter(item => item.channel === channel && item.os === effectiveOs)
           .map(item => item.arch)
       ),
     ].map(item => ({
       label: item,
       value: item,
     }));
-  }, [channel, supportOptions, os]);
-
-  const renderFixedSelect = (value: any[]) => {
-    return !(value.length === 0 || (value.length === 1 && value[0].value === "any"));
-  };
+  }, [channel, supportOptions, os, availableOS]);
 
   const updateUrlParams = (newChannel: string, newOs: string, newArch: string) => {
     if (typeof window === "undefined") return;
@@ -240,7 +243,9 @@ export default function ProjectCard(props: ProjectCardProps) {
       // 如果 supportOption 中有自定义的 rid，使用它；否则使用原始的 resource
       const targetResource = currentOption?.rid || resource;
 
-      const dl = `${CLIENT_BACKEND}/api/resources/${targetResource}/latest?os=${os}&arch=${arch}&channel=${channel}&cdk=${cdk}&user_agent=mirrorchyan_web`;
+      const reqOs = os === "any" ? "" : os;
+      const reqArch = arch === "any" ? "" : arch;
+      const dl = `${CLIENT_BACKEND}/api/resources/${targetResource}/latest?os=${reqOs}&arch=${reqArch}&channel=${channel}&cdk=${cdk}&user_agent=mirrorchyan_web`;
       const response = await fetch(dl);
 
       const { code, msg, data } = await response.json();


### PR DESCRIPTION
- 将 renderFixedSelect 移至 availableArch 前，消除 TDZ 错误
- availableArch 在 OS 全为 any 时使用 "any" 作为过滤值，正确显示架构选项
- API 请求时将 os/arch 的 "any" 值转为空字符串

## Summary by Sourcery

调整项目下载选项对操作系统/架构为 "any" 时的处理方式，并修复初始化顺序以避免运行时错误。

Bug Fixes:
- 当所有受支持的操作系统值都是 "any" 时，通过使用 "any" 作为有效过滤条件，确保正确推导架构选项。
- 通过在记忆化计算中首次使用之前定义 fixed-select 辅助函数，防止与 TDZ 相关的运行时错误。
- 在资源 API 请求中，为 os/arch 查询参数发送空字符串而不是字面量 "any"，以符合后端的预期。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust project download option handling for OS/arch "any" values and fix initialization order to avoid runtime errors.

Bug Fixes:
- Ensure architecture options are correctly derived when all supported OS values are "any" by using "any" as the effective filter.
- Prevent TDZ-related runtime errors by defining the fixed-select helper before its first use in memoized computations.
- Send empty strings instead of literal "any" for os/arch query parameters in resource API requests to align with backend expectations.

</details>